### PR TITLE
implementing more general binning in kdcount.correlate

### DIFF
--- a/kdcount/correlate.py
+++ b/kdcount/correlate.py
@@ -208,7 +208,10 @@ class Binning(object):
                 integer[i] = numpy.ceil(x * self.inv[i])
             
             elif self.spacing[i] is None:
-                integer[i] = numpy.digitize(tobin[dim], self.edges[i])
+                if self.Ndim == 1:
+                    integer[i] = numpy.digitize(tobin[dim], self.edges)
+                else:
+                    integer[i] = numpy.digitize(tobin[dim], self.edges[i])
         
         return numpy.ravel_multi_index(integer, self.shape, mode='clip')
 

--- a/kdcount/correlate.py
+++ b/kdcount/correlate.py
@@ -170,9 +170,6 @@ class Binning(object):
         # store Rmax
         self.Rmax = self.max[0]
         
-        # remove self-pairs in `r` when using numpy.digitize in linear
-        if numpy.isclose(self.min[0], 0.) and self.spacing[0] is None: 
-            self.min[0] = 1e-5
             
     def linear(self, **tobin):
         """ 
@@ -201,17 +198,14 @@ class Binning(object):
                 integer[i] = numpy.ceil(x * self.inv[i])
 
             elif self.spacing[i] == 'logspace':
-
                 x = tobin[dim].copy()
                 x[x == 0] = self.min[i] * 0.9
                 x = numpy.log10(x / self.min[i])
                 integer[i] = numpy.ceil(x * self.inv[i])
-            
+
             elif self.spacing[i] is None:
-                if self.Ndim == 1:
-                    integer[i] = numpy.digitize(tobin[dim], self.edges)
-                else:
-                    integer[i] = numpy.digitize(tobin[dim], self.edges[i])
+                edge = self.edges if self.Ndim == 1 else self.edges[i]
+                integer[i] = numpy.searchsorted(edge, tobin[dim], side='left')
         
         return numpy.ravel_multi_index(integer, self.shape, mode='clip')
 

--- a/kdcount/correlate.py
+++ b/kdcount/correlate.py
@@ -187,7 +187,7 @@ class Binning(object):
         -------
         linearlized bin index
         """ 
-        N = len(tobin[tobin.keys()[0]])
+        N = len(tobin[list(tobin.keys())[0]])
         integer = numpy.empty(N, ('i8', (self.Ndim,))).T
         
         # do each dimension

--- a/kdcount/correlate.py
+++ b/kdcount/correlate.py
@@ -121,6 +121,10 @@ class Binning(object):
         
         # setup the info we need from the edges
         self._setup()
+        
+        if self.Ndim == 1:
+            self.edges   = self.edges[0]
+            self.centers = self.centers[0]
                             
         # for storing the mean values in each bin
         # computed when pair counting

--- a/kdcount/correlate.py
+++ b/kdcount/correlate.py
@@ -607,10 +607,10 @@ class paircount(object):
         # run the work, using a context manager
         with paircount_worker(self, binning, [data1, data2], np=np, usefast=usefast) as worker:
             with utils.MapReduce(np=worker.np) as pool:
-                pool.map(worker, range(worker.size), reduce=worker.reduce)
+                pool.map(worker.work, range(worker.size), reduce=worker.reduce)
 
 
-class paircount_worker():
+class paircount_worker(object):
     """
     Context that runs the actual pair counting, attaching the appropriate 
     attributes to the parent `paircount`
@@ -637,7 +637,7 @@ class paircount_worker():
         self.usefast = usefast
         
         # set the wrapped callables that do the work
-        self.__call__ = lambda i: self.__work__(i)
+        self.work = lambda i: self.__work__(i)
         self.reduce = lambda *args: self.__reduce__(*args)
         
     def __work__(self, i):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extensions = [
         myext("kdcount.pykdcount", ["kdcount/pykdcount.pyx"])
         ]
 
-setup(name="kdcount", version="0.3.1",
+setup(name="kdcount", version="0.3.2",
       author="Yu Feng",
       author_email="rainwoodman@gmail.com",
       description="A slower KDTree cross correlator",

--- a/tests/test_correlate.py
+++ b/tests/test_correlate.py
@@ -7,7 +7,7 @@ def test_simple():
     numpy.random.seed(1234)
     pos = numpy.random.uniform(size=(10, 3))
     dataset = correlate.points(pos, boxsize=1.0)
-    binning = correlate.RBinning(0.5, Nbins=10)
+    binning = correlate.RBinning(numpy.linspace(0.5, 10))
     r = correlate.paircount(dataset, dataset, binning, np=0)
 
     r1 = correlate.paircount(dataset, dataset, binning, usefast=True, np=0)
@@ -19,7 +19,7 @@ def test_unweighted():
     numpy.random.seed(1234)
     pos = numpy.random.uniform(size=(4000, 3))
     dataset = correlate.points(pos, boxsize=1.0)
-    binning = correlate.RBinning(0.5, Nbins=10)
+    binning = correlate.RBinning(numpy.linspace(0, 0.5, 10))
     r = correlate.paircount(dataset, dataset, binning, np=0)
 
     assert_allclose(
@@ -36,7 +36,7 @@ def test_weighted():
     numpy.random.seed(1234)
     pos = numpy.random.uniform(size=(4000, 3))
     dataset = correlate.points(pos, boxsize=1.0, weights=numpy.ones(len(pos)))
-    binning = correlate.RBinning(0.5, Nbins=10)
+    binning = correlate.RBinning(numpy.linspace(0, 0.5, 10))
     r = correlate.paircount(dataset, dataset, binning, np=0)
 
     assert_allclose(
@@ -50,7 +50,7 @@ def test_field():
     pos = numpy.random.uniform(size=(4000, 3))
     dataset = correlate.field(pos, value=numpy.ones(len(pos)), 
             boxsize=1.0, weights=numpy.ones(len(pos)))
-    binning = correlate.RBinning(0.5, Nbins=10)
+    binning = correlate.RBinning(numpy.linspace(0, 0.5, 10))
     r = correlate.paircount(dataset, dataset, binning, np=0)
 
     assert_allclose(

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -16,7 +16,7 @@ def test_cluster():
 
     assert r.N == len(dataset)
 
-    binning = sphere.AngularBinning(1.0, 10)
+    binning = sphere.AngularBinning(numpy.linspace(0, 1.0, 10))
 
     r = correlate.paircount(dataset, dataset, binning=binning, usefast=False)
     assert_allclose( 


### PR DESCRIPTION
- `Binning` base class just takes the edges now
- linear/log spacing case determined from edges and same code used
- for general, non-uniform binning case, numpy.digitize is used
- also, cleaned up the code in paircount.**init** to use a context manager, which I think is a bit more clear for the initialization and finalize methods
