### PR TITLE
Fix fof with indirect inputs.

### DIFF
--- a/kdcount/__init__.py
+++ b/kdcount/__init__.py
@@ -82,7 +82,7 @@ class KDNode(_core.KDNode):
             Returns: the label
         """
         if out is None:
-            out = numpy.empty(self.size, dtype='intp')
+            out = numpy.arange(len(self.tree.input), dtype='intp')
         return _core.KDNode.fof(self, linkinglength, out, method)
 
     def integrate(self, min, max, attr=None, info={}):

--- a/kdcount/kd_fof.c
+++ b/kdcount/kd_fof.c
@@ -250,8 +250,9 @@ kd_fof_internal(KDNode * node, double linking_length, ptrdiff_t * head, int safe
     trav->heuristics = heuristics;
     trav->buggy = buggy;
     ptrdiff_t i;
-    for(i = 0; i < node->size; i ++) {
-        trav->head[i] = i;
+    for(i = node->start; i < node->start + node->size; i ++) {
+        ptrdiff_t j = trav->ind[i];
+        trav->head[j] = j;
     }
 
     trav->visited = 0;
@@ -265,8 +266,9 @@ kd_fof_internal(KDNode * node, double linking_length, ptrdiff_t * head, int safe
 
     kd_enum_full(nodes, linking_length, NULL, _kd_fof_check_nodes, _kd_fof_visit_node, 1.0, 1, trav);
 
-    for(i = 0; i < node->size; i ++) {
-        trav->head[i] = splay(trav, i);
+    for(i = node->start; i < node->start + node->size; i ++) {
+        ptrdiff_t j = trav->ind[i];
+        trav->head[j] = splay(trav, j);
     }
 
     free(trav->node_connected);

--- a/kdcount/kd_fof_linkedlist.c
+++ b/kdcount/kd_fof_linkedlist.c
@@ -66,21 +66,22 @@ extern struct {
 } last_traverse;
 
 int 
-kd_fof_linkedlist(KDNode * tree, double linking_length, ptrdiff_t * head)
+kd_fof_linkedlist(KDNode * node, double linking_length, ptrdiff_t * head)
 {
-    KDNode * nodes[2] = {tree, tree};
+    KDNode * nodes[2] = {node, node};
     TraverseData * trav = & (TraverseData) {};
 
     trav->head = head;
-    trav->next = malloc(sizeof(trav->next[0]) * tree->size);
-    trav->len = malloc(sizeof(trav->len[0]) * tree->size);
+    trav->next = malloc(sizeof(trav->next[0]) * node->tree->input.dims[0]);
+    trav->len = malloc(sizeof(trav->len[0]) * node->tree->input.dims[0]);
     trav->ll = linking_length;
 
     ptrdiff_t i;
-    for(i = 0; i < tree->size; i ++) {
-        trav->head[i] = i;
-        trav->next[i] = -1;
-        trav->len[i] = 1;
+    for(i = node->start; i < node->start + node->size; i ++) {
+        ptrdiff_t j = node->tree->ind[i];
+        trav->head[j] = j;
+        trav->next[j] = -1;
+        trav->len[j] = 1;
     }
 
     trav->visited = 0;

--- a/kdcount/kdtree.h
+++ b/kdcount/kdtree.h
@@ -266,7 +266,7 @@ kd_enum_full(KDNode * nodes[2], double maxr,
 int
 kd_fof(KDNode * tree, double linking_length, ptrdiff_t * head);
 int
-kd_fof_linked_list(KDNode * tree, double linking_length, ptrdiff_t * head);
+kd_fof_linkedlist(KDNode * tree, double linking_length, ptrdiff_t * head);
 int
 kd_fof_allpairs(KDNode * tree, double linking_length, ptrdiff_t * head);
 int 

--- a/kdcount/pykdcount.pyx
+++ b/kdcount/pykdcount.pyx
@@ -270,6 +270,7 @@ cdef class KDNode:
 
     def fof(self, double linkinglength, numpy.ndarray out, method):
         assert out.dtype == numpy.dtype('intp')
+        assert len(out) == len(self.tree.input)
 
         if method == 'linkedlist':
             rt = kd_fof_linkedlist(self.ref, linkinglength, <npy_intp*> out.data)


### PR DESCRIPTION
We need to properly initialize head array when the input indirect.

This PR also clarifies that the head array shall be the same length as the input data.

kd_fof will not modify entries in the head array that does not correspond to particles
in the node.

This fix likely resolves the FOF bug mentioned in https://github.com/rainwoodman/fastpm/pull/61